### PR TITLE
(fix) compatibility with WP CLI >= 2.5.0 

### DIFF
--- a/command.php
+++ b/command.php
@@ -166,7 +166,7 @@ class S3Migration_Command
     $progress = WP_CLI\Utils\make_progress_bar('Migrating attachments', count($notOffloadedIds));
 
     $settings = $as3cf->get_settings(true);
-    WP_CLI::debug(print_r($settings));
+    WP_CLI::debug(print_r($settings,true));
 
     $items = array();
     foreach ($notOffloadedIds as $index => $postId) {


### PR DESCRIPTION
### Bug report:
Method **[print_r()](https://www.php.net/manual/en/function.print-r.php)** returns boolean value per default and this leads to the following error when passed to **WP_CLI::debug()** using **WP CLI** version >= 2.5.0:
`Fatal error: Uncaught InvalidArgumentException: Unsupported argument type passed to WP_CLI::error_to_string(): 'boolean'`

### Reason:
As of WP CLI version 2.5.0 method **WP_CLI::error_to_string()** returns an exception on invalid arguments.
Ref: https://github.com/wp-cli/wp-cli/issues/5356
